### PR TITLE
feat(logging): Implement better webdriver command logging

### DIFF
--- a/lib/webdriver_logger.ts
+++ b/lib/webdriver_logger.ts
@@ -39,17 +39,26 @@ export class WebDriverLogger {
     if (!this.logStream) {
       return;
     }
-    let cmdLog = this.printCommand(command);
+    //let cmdLog = this.printCommand(command);
 
     let logLine: string;
     if (command.getParam('sessionId')) {
       let session = command.getParam('sessionId').slice(0, 6);
-      logLine = `${this.timestamp()} [${session}] ${cmdLog}\n`;
+      logLine = `${this.timestamp()} [${session}]`;
     } else {
-      logLine = `${this.timestamp()} ${cmdLog}\n`;
+      logLine = `${this.timestamp()}`;
     }
 
-    this.logStream.write(logLine);
+    let started = Date.now();
+    command.on('response', () => {
+      let done = Date.now();
+      let elapsed = (done-started)/1000;
+      logLine += `${elapsed}s | ${CommandName[command.commandName]}\n`;
+      this.logStream.write(logLine);
+      if(command.commandName == CommandName.FindElement) {
+        this.logStream.write(JSON.stringify(command.responseData));
+      }
+    });
   }
 
   printCommand(command: WebDriverCommand) {

--- a/lib/webdriver_logger.ts
+++ b/lib/webdriver_logger.ts
@@ -9,6 +9,17 @@ function getLogId() {
   return Math.floor(Math.random() * Number.MAX_SAFE_INTEGER).toString(36).slice(0, 8);
 }
 
+//
+function padField(field: string): string {
+  const fieldWidth = 6;
+  let padding = fieldWidth - field.length;
+  if (padding > 0) {
+    return ' '.repeat(padding) + field;
+  }
+  return field;
+}
+
+
 const FINDERS = [
   CommandName.FindElement, CommandName.FindElementFromElement, CommandName.FindElements,
   CommandName.FindElementsFromElement
@@ -62,12 +73,13 @@ export class WebDriverLogger {
     let started = Date.now();
     command.on('response', () => {
       let done = Date.now();
-      let elapsed = (done - started) / 1000;
+      let elapsed = padField((done - started) + '');
+
       if (command.commandName == CommandName.NewSession) {
         let session = command.responseData['sessionId'].slice(0, 6);
         logLine += `| ${session} `;
       }
-      logLine += `| ${elapsed}s | ${CommandName[command.commandName]}`;
+      logLine += `| ${elapsed}ms | ${CommandName[command.commandName]}`;
       if (command.commandName == CommandName.Go) {
         logLine += ' ' + command.data['url'];
       } else if (command.getParam('elementId')) {

--- a/lib/webdriver_logger.ts
+++ b/lib/webdriver_logger.ts
@@ -9,7 +9,7 @@ function getLogId() {
   return Math.floor(Math.random() * Number.MAX_SAFE_INTEGER).toString(36).slice(0, 8);
 }
 
-//
+// Super proprietary left pad implementation. Do not copy plzkthx.
 function leftPad(field: string): string {
   const fieldWidth = 6;
   let padding = fieldWidth - field.length;
@@ -60,7 +60,6 @@ export class WebDriverLogger {
     if (!this.logStream) {
       return;
     }
-    // let cmdLog = this.printCommand(command);
 
     let logLine: string;
     logLine = `${this.timestamp()} `;
@@ -147,6 +146,6 @@ export class WebDriverLogger {
     let seconds = d.getSeconds() < 10 ? '0' + d.getSeconds() : d.getSeconds();
     let millis = d.getMilliseconds().toString();
     millis = '000'.slice(0, 3 - millis.length) + millis;
-    return `[${hours}:${minutes}:${seconds}.${millis}]`;
+    return `${hours}:${minutes}:${seconds}.${millis}`;
   }
 }

--- a/spec/e2e/logging_spec.ts
+++ b/spec/e2e/logging_spec.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as readline from 'readline';
-//import * as rimraf from 'rimraf';
+// import * as rimraf from 'rimraf';
 import * as webdriver from 'selenium-webdriver';
 
 import {BlockingProxy} from '../../lib/blockingproxy';
@@ -27,7 +27,7 @@ Example log of a test sessionv
  */
 
 
-fdescribe('Logger', () => {
+describe('Logger', () => {
   let driver: webdriver.WebDriver;
   let bp: BlockingProxy;
   let logDir: string;
@@ -56,9 +56,10 @@ fdescribe('Logger', () => {
     bp.enableLogging(logDir);
   });
 
-  afterEach((done) => {
-    //rimraf(logDir, done);
-  });
+  afterEach(
+      (done) => {
+          // rimraf(logDir, done);
+      });
 
   it('creates a log file', async() => {
     await driver.get('http://localhost:8081/ng1/#/async');
@@ -92,7 +93,7 @@ fdescribe('Logger', () => {
     await otherDriver.quit();
   });
 
-  fit('logs information about element finders', async() => {
+  it('logs information about element finders', async() => {
     await driver.get('http://localhost:8081/ng1/#/interaction');
     let el = driver.findElement(webdriver.By.id('flux'));
     await el.click();
@@ -102,17 +103,29 @@ fdescribe('Logger', () => {
     await el.getTagName();
     await el.getText();
     await el.getSize();
+
     try {
-    await el.clear();
+      await el.clear();
 
       el = driver.findElement(webdriver.By.css('.none'));
       await el.click();
-    } catch(e) {
-
+    } catch (e) {
     }
 
 
     let logLines = await readLog();
     console.log(logLines);
+  });
+
+  it('handles missing elements', async() => {
+    await driver.get('http://localhost:8081/ng1/#/interaction');
+    let el = driver.findElement(webdriver.By.id('flux'));
+    try {
+      await el.clear();
+
+      el = driver.findElement(webdriver.By.css('.none'));
+      await el.click();
+    } catch (e) {
+    }
   });
 });

--- a/spec/e2e/logging_spec.ts
+++ b/spec/e2e/logging_spec.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as readline from 'readline';
-// import * as rimraf from 'rimraf';
+import * as rimraf from 'rimraf';
 import * as webdriver from 'selenium-webdriver';
 
 import {BlockingProxy} from '../../lib/blockingproxy';
@@ -9,21 +9,15 @@ import {BlockingProxy} from '../../lib/blockingproxy';
 import {BP_URL, getTestEnv} from './environment';
 
 /*
-Example log of a test sessionv
+Example log of a test session
 
-[12:51:30] Getting new "chrome" session
-[12:51:33] [abcdef] [0.5s] Navigating to 'http://localhost/stuff'
-[12:51:35] [abcdef] [0.3s] Wait for Angular
-[12:51:36] [abcdef] [0.01s] Click on css '.test_element'
-[12:51:36] [abcdef] Move mouse by (0,50)
-[12:51:37] [abcdef] Click on binding 'thinger'
-
-12:15:36 | abcdef | 0.5s | NewSession
-  {
-    url: http:something.com/
-  }
-  Response:
-
+[20:08:14.830] |    834ms | 37f13c | NewSession',
+    {"browserName":"chrome"}',
+[20:08:15.674] |      4ms | 37f13c | SetTimeouts',
+[20:08:15.681] |    578ms | 37f13c | Go http://localhost:8081/ng1/#/interaction',
+[20:08:16.300] |    438ms | 37f13c | FindElement',
+    Using css selector \'.none\'',
+    ERROR: no such element'
  */
 
 
@@ -56,10 +50,9 @@ describe('Logger', () => {
     bp.enableLogging(logDir);
   });
 
-  afterEach(
-      (done) => {
-          // rimraf(logDir, done);
-      });
+  afterEach((done) => {
+    rimraf(logDir, done);
+  });
 
   it('creates a log file', async() => {
     await driver.get('http://localhost:8081/ng1/#/async');
@@ -85,15 +78,15 @@ describe('Logger', () => {
     let logLines = await readLog();
     let sessionId1 = session1.getId().slice(0, 6);
     let sessionId2 = session2.getId().slice(0, 6);
-    expect(logLines[1])
-        .toContain(`[${sessionId1}] Navigating to http://localhost:8081/ng1/#/interaction`);
-    expect(logLines[2])
-        .toContain(`[${sessionId2}] Navigating to http://localhost:8081/ng1/#/async`);
+    expect(logLines[2]).toContain(`Go http://localhost:8081/ng1/#/interaction`);
+    expect(logLines[2]).toContain(sessionId1);
+    expect(logLines[3]).toContain(`Go http://localhost:8081/ng1/#/async`);
+    expect(logLines[3]).toContain(sessionId2);
 
     await otherDriver.quit();
   });
 
-  fit('logs information about element finders', async() => {
+  it('logs information about element finders', async() => {
     await driver.get('http://localhost:8081/ng1/#/interaction');
     let el = driver.findElement(webdriver.By.id('flux'));
     await el.click();
@@ -104,28 +97,29 @@ describe('Logger', () => {
     await el.getText();
     await el.getSize();
 
-    try {
-      await el.clear();
-
-      el = driver.findElement(webdriver.By.css('.none'));
-      await el.click();
-    } catch (e) {
-    }
-
-
     let logLines = await readLog();
-    console.log(logLines);
+    let expectedLog = [
+      'Go http://localhost:8081/ng1/#/interaction', 'FindElement',
+      'Using css selector \'*[id="flux"]\'', 'Elements: 0', 'ElementClick (0)',
+      'GetElementCSSValue (0)', 'GetElementAttribute (0)', '    null', 'GetElementTagName (0)',
+      '    button', 'GetElementText (0)', '    Status: fluxing', 'GetElementRect (0)',
+      '    {"width":88,"hCode":88,"class":"org.openqa.selenium.Dimension","height":20}'
+    ];
+    for (let line in expectedLog) {
+      expect(logLines[line]).toContain(expectedLog[line], `Expected line: ${line} to match`);
+    }
   });
 
-  fit('handles missing elements', async() => {
+  it('handles selenium errors', async() => {
     await driver.get('http://localhost:8081/ng1/#/interaction');
-    let el = driver.findElement(webdriver.By.id('flux'));
     try {
-      await el.clear();
-
-      el = driver.findElement(webdriver.By.css('.none'));
+      let el = driver.findElement(webdriver.By.css('.none'));
       await el.click();
     } catch (e) {
+      // Nothing to do.
     }
+
+    let logLines = await readLog();
+    expect(logLines[3]).toContain('ERROR: no such element');
   });
 });

--- a/spec/e2e/logging_spec.ts
+++ b/spec/e2e/logging_spec.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as readline from 'readline';
-import * as rimraf from 'rimraf';
+//import * as rimraf from 'rimraf';
 import * as webdriver from 'selenium-webdriver';
 
 import {BlockingProxy} from '../../lib/blockingproxy';
@@ -57,7 +57,7 @@ fdescribe('Logger', () => {
   });
 
   afterEach((done) => {
-    rimraf(logDir, done);
+    //rimraf(logDir, done);
   });
 
   it('creates a log file', async() => {
@@ -90,5 +90,22 @@ fdescribe('Logger', () => {
         .toContain(`[${sessionId2}] Navigating to http://localhost:8081/ng1/#/async`);
 
     await otherDriver.quit();
+  });
+
+  fit('logs information about element finders', async() => {
+    await driver.get('http://localhost:8081/ng1/#/interaction');
+    let el = driver.findElement(webdriver.By.id('flux'));
+    await el.click();
+
+    try {
+      el = driver.findElement(webdriver.By.css('.none'));
+      await el.click();
+    } catch(e) {
+
+    }
+
+
+    let logLines = await readLog();
+    console.log(logLines);
   });
 });

--- a/spec/e2e/logging_spec.ts
+++ b/spec/e2e/logging_spec.ts
@@ -97,7 +97,14 @@ fdescribe('Logger', () => {
     let el = driver.findElement(webdriver.By.id('flux'));
     await el.click();
 
+    await el.getCssValue('fake-color');
+    await el.getAttribute('fake-attr');
+    await el.getTagName();
+    await el.getText();
+    await el.getSize();
     try {
+    await el.clear();
+
       el = driver.findElement(webdriver.By.css('.none'));
       await el.click();
     } catch(e) {

--- a/spec/e2e/logging_spec.ts
+++ b/spec/e2e/logging_spec.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as readline from 'readline';
-import * as rimraf from 'rimraf';
+//import * as rimraf from 'rimraf';
 import * as webdriver from 'selenium-webdriver';
 
 import {BlockingProxy} from '../../lib/blockingproxy';
@@ -51,7 +51,7 @@ describe('Logger', () => {
   });
 
   afterEach((done) => {
-    rimraf(logDir, done);
+    //rimraf(logDir, done);
   });
 
   it('creates a log file', async() => {
@@ -102,8 +102,7 @@ describe('Logger', () => {
       'Go http://localhost:8081/ng1/#/interaction', 'FindElement',
       'Using css selector \'*[id="flux"]\'', 'Elements: 0', 'ElementClick (0)',
       'GetElementCSSValue (0)', 'GetElementAttribute (0)', '    null', 'GetElementTagName (0)',
-      '    button', 'GetElementText (0)', '    Status: fluxing', 'GetElementRect (0)',
-      '    {"width":88,"hCode":88,"class":"org.openqa.selenium.Dimension","height":20}'
+      '    button', 'GetElementText (0)', '    Status: fluxing', 'GetElementRect (0)'
     ];
     for (let line in expectedLog) {
       expect(logLines[line]).toContain(expectedLog[line], `Expected line: ${line} to match`);

--- a/spec/e2e/logging_spec.ts
+++ b/spec/e2e/logging_spec.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as readline from 'readline';
-//import * as rimraf from 'rimraf';
+import * as rimraf from 'rimraf';
 import * as webdriver from 'selenium-webdriver';
 
 import {BlockingProxy} from '../../lib/blockingproxy';
@@ -11,11 +11,11 @@ import {BP_URL, getTestEnv} from './environment';
 /*
 Example log of a test session
 
-[20:08:14.830] |    834ms | 37f13c | NewSession',
+20:08:14.830 |    834ms | 37f13c | NewSession',
     {"browserName":"chrome"}',
-[20:08:15.674] |      4ms | 37f13c | SetTimeouts',
-[20:08:15.681] |    578ms | 37f13c | Go http://localhost:8081/ng1/#/interaction',
-[20:08:16.300] |    438ms | 37f13c | FindElement',
+20:08:15.674 |      4ms | 37f13c | SetTimeouts',
+20:08:15.681 |    578ms | 37f13c | Go http://localhost:8081/ng1/#/interaction',
+20:08:16.300 |    438ms | 37f13c | FindElement',
     Using css selector \'.none\'',
     ERROR: no such element'
  */
@@ -51,7 +51,7 @@ describe('Logger', () => {
   });
 
   afterEach((done) => {
-    //rimraf(logDir, done);
+    rimraf(logDir, done);
   });
 
   it('creates a log file', async() => {

--- a/spec/e2e/logging_spec.ts
+++ b/spec/e2e/logging_spec.ts
@@ -93,7 +93,7 @@ describe('Logger', () => {
     await otherDriver.quit();
   });
 
-  it('logs information about element finders', async() => {
+  fit('logs information about element finders', async() => {
     await driver.get('http://localhost:8081/ng1/#/interaction');
     let el = driver.findElement(webdriver.By.id('flux'));
     await el.click();
@@ -117,7 +117,7 @@ describe('Logger', () => {
     console.log(logLines);
   });
 
-  it('handles missing elements', async() => {
+  fit('handles missing elements', async() => {
     await driver.get('http://localhost:8081/ng1/#/interaction');
     let el = driver.findElement(webdriver.By.id('flux'));
     try {

--- a/spec/e2e/logging_spec.ts
+++ b/spec/e2e/logging_spec.ts
@@ -9,7 +9,7 @@ import {BlockingProxy} from '../../lib/blockingproxy';
 import {BP_URL, getTestEnv} from './environment';
 
 /*
-Example log of a test session:
+Example log of a test sessionv
 
 [12:51:30] Getting new "chrome" session
 [12:51:33] [abcdef] [0.5s] Navigating to 'http://localhost/stuff'
@@ -17,10 +17,17 @@ Example log of a test session:
 [12:51:36] [abcdef] [0.01s] Click on css '.test_element'
 [12:51:36] [abcdef] Move mouse by (0,50)
 [12:51:37] [abcdef] Click on binding 'thinger'
+
+12:15:36 | abcdef | 0.5s | NewSession
+  {
+    url: http:something.com/
+  }
+  Response:
+
  */
 
 
-describe('Logger', () => {
+fdescribe('Logger', () => {
   let driver: webdriver.WebDriver;
   let bp: BlockingProxy;
   let logDir: string;

--- a/spec/helpers/mock_selenium.ts
+++ b/spec/helpers/mock_selenium.ts
@@ -60,33 +60,44 @@ let isElementSelected =
 
 // Get Element Attribute
 let getElementAttribute = new Command<Session>(
-    'GET', 'element/:elementId/attribute/:attributeName', (session, params) => {});
+    'GET', 'element/:elementId/attribute/:attributeName', (session, params) => {
+      return 'null';
+    });
 
 // Get Element Property
-let getElementProperty = new Command<Session>(
-    'GET', 'element/:elementId/property/:propertyName', (session, params) => {
-      return "Property";
+let getElementProperty =
+    new Command<Session>('GET', 'element/:elementId/property/:propertyName', (session, params) => {
+      return 'Property';
     });
 
 // Get Element CSS Value
 let getElementCSSValue =
-    new Command<Session>('GET', 'element/:elementId/css/:cssPropertyName', (session, params) => {});
+    new Command<Session>('GET', 'element/:elementId/css/:cssPropertyName', (session, params) => {
+      return 'white';
+    });
 
 // Get Element Text
-let getElementText =
-    new Command<Session>('GET', 'element/:elementId/text', (session, params) => {});
+let getElementText = new Command<Session>('GET', 'element/:elementId/text', (session, params) => {
+  return 'some text';
+});
 
 // Get Element Tag Name
 let getElementTagName =
-    new Command<Session>('GET', 'element/:elementId/name', (session, params) => {});
+    new Command<Session>('GET', 'element/:elementId/name', (session, params) => {
+      return 'button';
+    });
 
 // Get Element Rect
-let getElementRect =
-    new Command<Session>('GET', 'element/:elementId/rect', (session, params) => {});
+let getElementRect = new Command<Session>('GET', 'element/:elementId/rect', (session, params) => {
+  return {width: 88, hCode: 88, class: 'org.openqa.selenium.Dimension', height: 20};
+});
 
 // Get Element Rect from JSON Wire protocol (not W3C spec)
 let getElementRectWire =
-    new Command<Session>('GET', 'element/:elementId/size', (session, params) => {});
+    new Command<Session>('GET', 'element/:elementId/size', (session, params) => {
+      return {width: 88, hCode: 88, class: 'org.openqa.selenium.Dimension', height: 20};
+    });
+
 
 // Is Element Enabled
 let isElementEnabled =

--- a/spec/helpers/mock_selenium.ts
+++ b/spec/helpers/mock_selenium.ts
@@ -39,7 +39,7 @@ let findElement = new Command<Session>('POST', 'element', (session, params) => {
 
 // Find Elements
 let findElements = new Command<Session>('POST', 'elements', (session, params) => {
-  return [{'ELEMENT': '0'}];
+  return [{'ELEMENT': '0'}, {'ELEMENT': '1'}];
 });
 
 // Find Element From Element
@@ -51,7 +51,7 @@ let findElementFromElement =
 // Find Elements From Element
 let findElementsFromElement =
     new Command<Session>('POST', 'element/:elementId/elements', (session, params) => {
-      return [{'ELEMENT': '0'}];
+      return [{'ELEMENT': '0'}, {'ELEMENT': '1'}];
     });
 
 // Is Element Selected
@@ -64,7 +64,9 @@ let getElementAttribute = new Command<Session>(
 
 // Get Element Property
 let getElementProperty = new Command<Session>(
-    'GET', 'element/:elementId/property/:propertyName', (session, params) => {});
+    'GET', 'element/:elementId/property/:propertyName', (session, params) => {
+      return "Property";
+    });
 
 // Get Element CSS Value
 let getElementCSSValue =

--- a/spec/unit/webdriver_logger_spec.ts
+++ b/spec/unit/webdriver_logger_spec.ts
@@ -59,6 +59,10 @@ describe('WebDriver logger', () => {
     proxy.setLogger(logger);
   });
 
+  afterAll(() => {
+    mockServer.stop();
+  });
+
   beforeEach(async() => {
     driver = new webdriver.Builder()
                  .usingServer(`http://localhost:${bpPort}`)
@@ -122,21 +126,21 @@ describe('WebDriver logger', () => {
 
     let log = logger.getLog();
     let expectedLog = [
-      `[14:05:34.000] | ${shortSession} | 0s | FindElement\n`,
+      `[14:05:34.000] | ${shortSession} |      0ms | FindElement\n`,
       `    Using css selector '.test'\n`,
       `    Elements: 0\n`,
-      `[14:05:34.000] | ${shortSession} | 0s | ElementClick (0)\n`,
-      `[14:05:34.000] | ${shortSession} | 0s | ElementClear (0)\n`,
-      `[14:05:34.000] | ${shortSession} | 0s | ElementSendKeys (0)\n`,
+      `[14:05:34.000] | ${shortSession} |      0ms | ElementClick (0)\n`,
+      `[14:05:34.000] | ${shortSession} |      0ms | ElementClear (0)\n`,
+      `[14:05:34.000] | ${shortSession} |      0ms | ElementSendKeys (0)\n`,
       `    Send: test string\n`,
-      `[14:05:34.000] | ${shortSession} | 0s | FindElementFromElement (0)\n`,
+      `[14:05:34.000] | ${shortSession} |      0ms | FindElementFromElement (0)\n`,
       `    Using css selector '.inner_thing'\n`,
       `    Elements: 0\n`,
-      `[14:05:34.000] | ${shortSession} | 0s | ElementClick (0)\n`,
-      `[14:05:34.000] | ${shortSession} | 0s | FindElements\n`,
+      `[14:05:34.000] | ${shortSession} |      0ms | ElementClick (0)\n`,
+      `[14:05:34.000] | ${shortSession} |      0ms | FindElements\n`,
       `    Using css selector '*[id=\"thing\"]'\n`,
       `    Elements: 0,1\n`,
-      `[14:05:34.000] | ${shortSession} | 0s | FindElementsFromElement (0)\n`,
+      `[14:05:34.000] | ${shortSession} |      0ms | FindElementsFromElement (0)\n`,
       `    Using css selector '.inner_thing'\n`,
       `    Elements: 0,1\n`,
     ];
@@ -160,18 +164,18 @@ describe('WebDriver logger', () => {
     let log = logger.getLog();
 
     let expectedLog = [
-      `[14:05:34.000] | ${shortSession} | 0s | FindElement\n`,
+      `[14:05:34.000] | ${shortSession} |      0ms | FindElement\n`,
       `    Using css selector '.test'\n`,
       `    Elements: 0\n`,
-      `[14:05:34.000] | ${shortSession} | 0s | GetElementCSSValue (0)\n`,
+      `[14:05:34.000] | ${shortSession} |      0ms | GetElementCSSValue (0)\n`,
       `    white\n`,
-      `[14:05:34.000] | ${shortSession} | 0s | GetElementAttribute (0)\n`,
+      `[14:05:34.000] | ${shortSession} |      0ms | GetElementAttribute (0)\n`,
       `    null\n`,
-      `[14:05:34.000] | ${shortSession} | 0s | GetElementTagName (0)\n`,
+      `[14:05:34.000] | ${shortSession} |      0ms | GetElementTagName (0)\n`,
       `    button\n`,
-      `[14:05:34.000] | ${shortSession} | 0s | GetElementText (0)\n`,
+      `[14:05:34.000] | ${shortSession} |      0ms | GetElementText (0)\n`,
       `    some text\n`,
-      `[14:05:34.000] | ${shortSession} | 0s | GetElementRect (0)\n`,
+      `[14:05:34.000] | ${shortSession} |      0ms | GetElementRect (0)\n`,
       `    {"width":88,"hCode":88,"class":"org.openqa.selenium.Dimension","height":20}\n`,
     ];
     for (let line in expectedLog) {
@@ -202,10 +206,6 @@ describe('WebDriver logger', () => {
     await delay;
 
     let log = logger.getLog();
-    expect(log[3]).toContain('[14:05:34.000] | abcdef | 1.234s | GetCurrentURL');
-  });
-
-  afterAll(() => {
-    mockServer.stop();
+    expect(log[3]).toContain('[14:05:34.000] | abcdef |   1234ms | GetCurrentURL');
   });
 });

--- a/spec/unit/webdriver_logger_spec.ts
+++ b/spec/unit/webdriver_logger_spec.ts
@@ -126,21 +126,21 @@ describe('WebDriver logger', () => {
 
     let log = logger.getLog();
     let expectedLog = [
-      `[22:05:34.000] |      0ms | ${shortSession} | FindElement\n`,
+      `22:05:34.000 |      0ms | ${shortSession} | FindElement\n`,
       `    Using css selector '.test'\n`,
       `    Elements: 0\n`,
-      `[22:05:34.000] |      0ms | ${shortSession} | ElementClick (0)\n`,
-      `[22:05:34.000] |      0ms | ${shortSession} | ElementClear (0)\n`,
-      `[22:05:34.000] |      0ms | ${shortSession} | ElementSendKeys (0)\n`,
+      `22:05:34.000 |      0ms | ${shortSession} | ElementClick (0)\n`,
+      `22:05:34.000 |      0ms | ${shortSession} | ElementClear (0)\n`,
+      `22:05:34.000 |      0ms | ${shortSession} | ElementSendKeys (0)\n`,
       `    Send: test string\n`,
-      `[22:05:34.000] |      0ms | ${shortSession} | FindElementFromElement (0)\n`,
+      `22:05:34.000 |      0ms | ${shortSession} | FindElementFromElement (0)\n`,
       `    Using css selector '.inner_thing'\n`,
       `    Elements: 0\n`,
-      `[22:05:34.000] |      0ms | ${shortSession} | ElementClick (0)\n`,
-      `[22:05:34.000] |      0ms | ${shortSession} | FindElements\n`,
+      `22:05:34.000 |      0ms | ${shortSession} | ElementClick (0)\n`,
+      `22:05:34.000 |      0ms | ${shortSession} | FindElements\n`,
       `    Using css selector '*[id=\"thing\"]'\n`,
       `    Elements: 0,1\n`,
-      `[22:05:34.000] |      0ms | ${shortSession} | FindElementsFromElement (0)\n`,
+      `22:05:34.000 |      0ms | ${shortSession} | FindElementsFromElement (0)\n`,
       `    Using css selector '.inner_thing'\n`,
       `    Elements: 0,1\n`,
     ];
@@ -164,18 +164,18 @@ describe('WebDriver logger', () => {
     let log = logger.getLog();
 
     let expectedLog = [
-      `[22:05:34.000] |      0ms | ${shortSession} | FindElement\n`,
+      `22:05:34.000 |      0ms | ${shortSession} | FindElement\n`,
       `    Using css selector '.test'\n`,
       `    Elements: 0\n`,
-      `[22:05:34.000] |      0ms | ${shortSession} | GetElementCSSValue (0)\n`,
+      `22:05:34.000 |      0ms | ${shortSession} | GetElementCSSValue (0)\n`,
       `    white\n`,
-      `[22:05:34.000] |      0ms | ${shortSession} | GetElementAttribute (0)\n`,
+      `22:05:34.000 |      0ms | ${shortSession} | GetElementAttribute (0)\n`,
       `    null\n`,
-      `[22:05:34.000] |      0ms | ${shortSession} | GetElementTagName (0)\n`,
+      `22:05:34.000 |      0ms | ${shortSession} | GetElementTagName (0)\n`,
       `    button\n`,
-      `[22:05:34.000] |      0ms | ${shortSession} | GetElementText (0)\n`,
+      `22:05:34.000 |      0ms | ${shortSession} | GetElementText (0)\n`,
       `    some text\n`,
-      `[22:05:34.000] |      0ms | ${shortSession} | GetElementRect (0)\n`,
+      `22:05:34.000 |      0ms | ${shortSession} | GetElementRect (0)\n`,
       `    {"width":88,"hCode":88,"class":"org.openqa.selenium.Dimension","height":20}\n`,
     ];
     for (let line in expectedLog) {
@@ -206,7 +206,7 @@ describe('WebDriver logger', () => {
     await delay;
 
     let log = logger.getLog();
-    expect(log[3]).toContain('[22:05:34.000] |   1234ms | abcdef | GetCurrentURL');
+    expect(log[3]).toContain('22:05:34.000 |   1234ms | abcdef | GetCurrentURL');
   });
 
   it('handles unknown commands', async() => {
@@ -219,10 +219,9 @@ describe('WebDriver logger', () => {
 
     let log = logger.getLog();
     let expectedLog = [
-      `[22:05:34.000] |      0ms | ${shortSession} | NewSession\n`,
-      `    {"browserName":"chrome"}\n`,
-      `[22:05:34.000] |      0ms | ${shortSession} | Go http://example.com\n`,
-      `[22:05:34.000] |      0ms | /session/abcdef/not_a_command\n`
+      `22:05:34.000 |      0ms | ${shortSession} | NewSession\n`, `    {"browserName":"chrome"}\n`,
+      `22:05:34.000 |      0ms | ${shortSession} | Go http://example.com\n`,
+      `22:05:34.000 |      0ms | /session/abcdef/not_a_command\n`
     ];
     for (let line in expectedLog) {
       expect(log[line]).toEqual(expectedLog[line], `Expected line: ${line} to match`);

--- a/spec/unit/webdriver_logger_spec.ts
+++ b/spec/unit/webdriver_logger_spec.ts
@@ -38,7 +38,7 @@ class InMemoryLogger extends WebDriverLogger {
   }
 }
 
-describe('WebDriver logger', () => {
+fdescribe('WebDriver logger', () => {
   let mockServer: Server<Session>;
   let driver: webdriver.WebDriver;
   let logger = new InMemoryLogger();
@@ -51,6 +51,7 @@ describe('WebDriver logger', () => {
     let mockPort = mockServer.handle.address().port;
 
     proxy = new BlockingProxy(`http://localhost:${mockPort}/wd/hub`);
+    proxy.waitEnabled = false;
     bpPort = proxy.listen(0);
     logger.setLogDir('.');
     proxy.setLogger(logger);
@@ -100,6 +101,26 @@ describe('WebDriver logger', () => {
 
     let log = logger.getLog();
     expect(log[1]).toContain(shortSession);
+  });
+
+  it('parses element commands', async() => {
+    let el = driver.findElement(webdriver.By.css('.test'));
+    await el.click();
+    await el.getCssValue('fake-color');
+    await el.getAttribute('fake-attr');
+    await el.getTagName();
+    await el.getText();
+    await el.getSize();
+    await el.clear();
+    await el.sendKeys('test string');
+
+    let inner = el.findElement(webdriver.By.css('.inner_thing'));
+    await inner.click();
+
+    await driver.findElements(webdriver.By.id('thing'));
+    await el.findElements(webdriver.By.css('.inner_thing'));
+
+    console.log(logger.getLog());
   });
 
   afterAll(() => {

--- a/spec/unit/webdriver_logger_spec.ts
+++ b/spec/unit/webdriver_logger_spec.ts
@@ -64,6 +64,9 @@ describe('WebDriver logger', () => {
   });
 
   beforeEach(async() => {
+    jasmine.clock().install();
+    jasmine.clock().mockDate(start);
+
     driver = new webdriver.Builder()
                  .usingServer(`http://localhost:${bpPort}`)
                  .withCapabilities(capabilities)
@@ -71,9 +74,6 @@ describe('WebDriver logger', () => {
 
     // Ensure WebDriver client has created a session by waiting on a command.
     await driver.get('http://example.com');
-
-    jasmine.clock().install();
-    jasmine.clock().mockDate(start);
   });
 
   afterEach(() => {
@@ -126,21 +126,21 @@ describe('WebDriver logger', () => {
 
     let log = logger.getLog();
     let expectedLog = [
-      `[14:05:34.000] | ${shortSession} |      0ms | FindElement\n`,
+      `[14:05:34.000] |      0ms | ${shortSession} | FindElement\n`,
       `    Using css selector '.test'\n`,
       `    Elements: 0\n`,
-      `[14:05:34.000] | ${shortSession} |      0ms | ElementClick (0)\n`,
-      `[14:05:34.000] | ${shortSession} |      0ms | ElementClear (0)\n`,
-      `[14:05:34.000] | ${shortSession} |      0ms | ElementSendKeys (0)\n`,
+      `[14:05:34.000] |      0ms | ${shortSession} | ElementClick (0)\n`,
+      `[14:05:34.000] |      0ms | ${shortSession} | ElementClear (0)\n`,
+      `[14:05:34.000] |      0ms | ${shortSession} | ElementSendKeys (0)\n`,
       `    Send: test string\n`,
-      `[14:05:34.000] | ${shortSession} |      0ms | FindElementFromElement (0)\n`,
+      `[14:05:34.000] |      0ms | ${shortSession} | FindElementFromElement (0)\n`,
       `    Using css selector '.inner_thing'\n`,
       `    Elements: 0\n`,
-      `[14:05:34.000] | ${shortSession} |      0ms | ElementClick (0)\n`,
-      `[14:05:34.000] | ${shortSession} |      0ms | FindElements\n`,
+      `[14:05:34.000] |      0ms | ${shortSession} | ElementClick (0)\n`,
+      `[14:05:34.000] |      0ms | ${shortSession} | FindElements\n`,
       `    Using css selector '*[id=\"thing\"]'\n`,
       `    Elements: 0,1\n`,
-      `[14:05:34.000] | ${shortSession} |      0ms | FindElementsFromElement (0)\n`,
+      `[14:05:34.000] |      0ms | ${shortSession} | FindElementsFromElement (0)\n`,
       `    Using css selector '.inner_thing'\n`,
       `    Elements: 0,1\n`,
     ];
@@ -164,18 +164,18 @@ describe('WebDriver logger', () => {
     let log = logger.getLog();
 
     let expectedLog = [
-      `[14:05:34.000] | ${shortSession} |      0ms | FindElement\n`,
+      `[14:05:34.000] |      0ms | ${shortSession} | FindElement\n`,
       `    Using css selector '.test'\n`,
       `    Elements: 0\n`,
-      `[14:05:34.000] | ${shortSession} |      0ms | GetElementCSSValue (0)\n`,
+      `[14:05:34.000] |      0ms | ${shortSession} | GetElementCSSValue (0)\n`,
       `    white\n`,
-      `[14:05:34.000] | ${shortSession} |      0ms | GetElementAttribute (0)\n`,
+      `[14:05:34.000] |      0ms | ${shortSession} | GetElementAttribute (0)\n`,
       `    null\n`,
-      `[14:05:34.000] | ${shortSession} |      0ms | GetElementTagName (0)\n`,
+      `[14:05:34.000] |      0ms | ${shortSession} | GetElementTagName (0)\n`,
       `    button\n`,
-      `[14:05:34.000] | ${shortSession} |      0ms | GetElementText (0)\n`,
+      `[14:05:34.000] |      0ms | ${shortSession} | GetElementText (0)\n`,
       `    some text\n`,
-      `[14:05:34.000] | ${shortSession} |      0ms | GetElementRect (0)\n`,
+      `[14:05:34.000] |      0ms | ${shortSession} | GetElementRect (0)\n`,
       `    {"width":88,"hCode":88,"class":"org.openqa.selenium.Dimension","height":20}\n`,
     ];
     for (let line in expectedLog) {
@@ -206,6 +206,26 @@ describe('WebDriver logger', () => {
     await delay;
 
     let log = logger.getLog();
-    expect(log[3]).toContain('[14:05:34.000] | abcdef |   1234ms | GetCurrentURL');
+    expect(log[3]).toContain('[14:05:34.000] |   1234ms | abcdef | GetCurrentURL');
   });
+
+  it('handles unknown commands', async() => {
+    let session = await driver.getSession();
+    let shortSession = session.getId().slice(0, 6);
+
+    let cmd = parseWebDriverCommand('/session/abcdef/not_a_command', 'GET');
+    logger.logWebDriverCommand(cmd);
+    cmd.handleResponse(200, {});
+
+    let log = logger.getLog();
+    let expectedLog = [
+      `[14:05:34.000] |      0ms | ${shortSession} | NewSession\n`,
+      `    {"browserName":"chrome"}\n`,
+      `[14:05:34.000] |      0ms | ${shortSession} | Go http://example.com\n`,
+      `[14:05:34.000] |      0ms | /session/abcdef/not_a_command\n`
+    ];
+    for (let line in expectedLog) {
+      expect(log[line]).toEqual(expectedLog[line], `Expected line: ${line} to match`);
+    }
+  })
 });

--- a/spec/unit/webdriver_logger_spec.ts
+++ b/spec/unit/webdriver_logger_spec.ts
@@ -45,7 +45,7 @@ describe('WebDriver logger', () => {
   let logger = new InMemoryLogger();
   let proxy: BlockingProxy;
   let bpPort: number;
-  let start = new Date('2017-01-26T22:05:34.000Z');
+  let start = new Date('2017-01-26 22:05:34.000');
 
   beforeAll(() => {
     mockServer = getMockSelenium();
@@ -126,21 +126,21 @@ describe('WebDriver logger', () => {
 
     let log = logger.getLog();
     let expectedLog = [
-      `[14:05:34.000] |      0ms | ${shortSession} | FindElement\n`,
+      `[22:05:34.000] |      0ms | ${shortSession} | FindElement\n`,
       `    Using css selector '.test'\n`,
       `    Elements: 0\n`,
-      `[14:05:34.000] |      0ms | ${shortSession} | ElementClick (0)\n`,
-      `[14:05:34.000] |      0ms | ${shortSession} | ElementClear (0)\n`,
-      `[14:05:34.000] |      0ms | ${shortSession} | ElementSendKeys (0)\n`,
+      `[22:05:34.000] |      0ms | ${shortSession} | ElementClick (0)\n`,
+      `[22:05:34.000] |      0ms | ${shortSession} | ElementClear (0)\n`,
+      `[22:05:34.000] |      0ms | ${shortSession} | ElementSendKeys (0)\n`,
       `    Send: test string\n`,
-      `[14:05:34.000] |      0ms | ${shortSession} | FindElementFromElement (0)\n`,
+      `[22:05:34.000] |      0ms | ${shortSession} | FindElementFromElement (0)\n`,
       `    Using css selector '.inner_thing'\n`,
       `    Elements: 0\n`,
-      `[14:05:34.000] |      0ms | ${shortSession} | ElementClick (0)\n`,
-      `[14:05:34.000] |      0ms | ${shortSession} | FindElements\n`,
+      `[22:05:34.000] |      0ms | ${shortSession} | ElementClick (0)\n`,
+      `[22:05:34.000] |      0ms | ${shortSession} | FindElements\n`,
       `    Using css selector '*[id=\"thing\"]'\n`,
       `    Elements: 0,1\n`,
-      `[14:05:34.000] |      0ms | ${shortSession} | FindElementsFromElement (0)\n`,
+      `[22:05:34.000] |      0ms | ${shortSession} | FindElementsFromElement (0)\n`,
       `    Using css selector '.inner_thing'\n`,
       `    Elements: 0,1\n`,
     ];
@@ -164,18 +164,18 @@ describe('WebDriver logger', () => {
     let log = logger.getLog();
 
     let expectedLog = [
-      `[14:05:34.000] |      0ms | ${shortSession} | FindElement\n`,
+      `[22:05:34.000] |      0ms | ${shortSession} | FindElement\n`,
       `    Using css selector '.test'\n`,
       `    Elements: 0\n`,
-      `[14:05:34.000] |      0ms | ${shortSession} | GetElementCSSValue (0)\n`,
+      `[22:05:34.000] |      0ms | ${shortSession} | GetElementCSSValue (0)\n`,
       `    white\n`,
-      `[14:05:34.000] |      0ms | ${shortSession} | GetElementAttribute (0)\n`,
+      `[22:05:34.000] |      0ms | ${shortSession} | GetElementAttribute (0)\n`,
       `    null\n`,
-      `[14:05:34.000] |      0ms | ${shortSession} | GetElementTagName (0)\n`,
+      `[22:05:34.000] |      0ms | ${shortSession} | GetElementTagName (0)\n`,
       `    button\n`,
-      `[14:05:34.000] |      0ms | ${shortSession} | GetElementText (0)\n`,
+      `[22:05:34.000] |      0ms | ${shortSession} | GetElementText (0)\n`,
       `    some text\n`,
-      `[14:05:34.000] |      0ms | ${shortSession} | GetElementRect (0)\n`,
+      `[22:05:34.000] |      0ms | ${shortSession} | GetElementRect (0)\n`,
       `    {"width":88,"hCode":88,"class":"org.openqa.selenium.Dimension","height":20}\n`,
     ];
     for (let line in expectedLog) {
@@ -206,7 +206,7 @@ describe('WebDriver logger', () => {
     await delay;
 
     let log = logger.getLog();
-    expect(log[3]).toContain('[14:05:34.000] |   1234ms | abcdef | GetCurrentURL');
+    expect(log[3]).toContain('[22:05:34.000] |   1234ms | abcdef | GetCurrentURL');
   });
 
   it('handles unknown commands', async() => {
@@ -219,10 +219,10 @@ describe('WebDriver logger', () => {
 
     let log = logger.getLog();
     let expectedLog = [
-      `[14:05:34.000] |      0ms | ${shortSession} | NewSession\n`,
+      `[22:05:34.000] |      0ms | ${shortSession} | NewSession\n`,
       `    {"browserName":"chrome"}\n`,
-      `[14:05:34.000] |      0ms | ${shortSession} | Go http://example.com\n`,
-      `[14:05:34.000] |      0ms | /session/abcdef/not_a_command\n`
+      `[22:05:34.000] |      0ms | ${shortSession} | Go http://example.com\n`,
+      `[22:05:34.000] |      0ms | /session/abcdef/not_a_command\n`
     ];
     for (let line in expectedLog) {
       expect(log[line]).toEqual(expectedLog[line], `Expected line: ${line} to match`);

--- a/spec/unit/webdriver_logger_spec.ts
+++ b/spec/unit/webdriver_logger_spec.ts
@@ -227,5 +227,5 @@ describe('WebDriver logger', () => {
     for (let line in expectedLog) {
       expect(log[line]).toEqual(expectedLog[line], `Expected line: ${line} to match`);
     }
-  })
+  });
 });


### PR DESCRIPTION
Hopefully, this covers #5. Webdriver command logs now look like this

```
20:08:14.830 |    834ms | 37f13c | NewSession
    {"browserName":"chrome"}
20:08:15.674 |      4ms | 37f13c | SetTimeouts
20:08:15.681 |    578ms | 37f13c | Go http://localhost:8081/ng1/#/interaction
20:08:16.300 |    438ms | 37f13c | FindElement
    Using css selector \'.invalid\'
    ERROR: no such element
```
or this
```
20:25:30.487 |    106ms | 73eefa | Go http://localhost:8081/ng1/#/interaction
20:25:30.620 |     25ms | 73eefa | FindElement
    Using css selector '*[id="flux"]'
    Elements: 0
20:25:30.658 |     55ms | 73eefa | ElementClick (0)
20:25:30.819 |      8ms | 73eefa | GetElementRect (0)
    {"width":88,"hCode":88,"class":"org.openqa.selenium.Dimension","height":20}
```
The second field is how long the command took. If a command has extra data associated with it, it's printed on the next line. If the response has important data (or if there's an error), it's printed on the line after that. For commands that accept an element ID, the id is put on the end of the first line in parens (`GetElementRect (0)` for example).

Commands are logged when the response from selenium is received, though the timestamp reflects when the proxy saw the command from upstream.

For commands that the proxy doesn't understand, it just shows the URL of the command and doesn't print any of the extra data.