### PR TITLE
Remove leftPad function comment

### DIFF
--- a/lib/webdriver_logger.ts
+++ b/lib/webdriver_logger.ts
@@ -9,7 +9,6 @@ function getLogId() {
   return Math.floor(Math.random() * Number.MAX_SAFE_INTEGER).toString(36).slice(0, 8);
 }
 
-// Super proprietary left pad implementation. Do not copy plzkthx.
 function leftPad(field: string): string {
   const fieldWidth = 6;
   let padding = fieldWidth - field.length;


### PR DESCRIPTION
Remove the comment on leftPad which needlessly raised concerns that the
code is actually proprietary.