### PR TITLE
minimist update

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "Julie Ralph <ju.ralph@gmail.com>"
   ],
   "dependencies": {
-    "minimist": "^1.2.0"
+    "minimist": "^1.2.3"
   },
   "devDependencies": {
     "@types/jasmine": "2.5.45",


### PR DESCRIPTION
minimist  before 1.2.2 could be tricked into adding or modifying properties of  Object.prototype using a "constructor" or "__proto__" payload.



